### PR TITLE
chore(#21): change project name to kpop stack

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -19,7 +19,7 @@ export default function Index() {
             <div className="lg:pb-18 relative px-4 pt-16 pb-8 sm:px-6 sm:pt-24 sm:pb-14 lg:px-8 lg:pt-32">
               <h1 className="text-center text-6xl font-extrabold tracking-tight sm:text-8xl lg:text-9xl">
                 <span className="block uppercase text-red-500 drop-shadow-md">
-                  Ska Stack
+                  K-Pop Stack
                 </span>
               </h1>
               <p className="mx-auto mt-6 max-w-lg text-center text-xl text-white sm:max-w-3xl">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-app-template",
+  "name": "kpop-stack-template",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-app-template",
+  "name": "kpop-stack-template",
   "private": true,
   "description": "",
   "license": "",


### PR DESCRIPTION
closes #21 
this mostly happened out of the code:
- [x] update repo information
- [x] update links to repo in netlify
- [x] update netlify project info
- [x] update supabase (✅ by @maxcell )
- [x] old name mention in homepage and package.json
