### PR TITLE
Adds ability to view and delete a note

### DIFF
--- a/app/models/note.server.ts
+++ b/app/models/note.server.ts
@@ -9,6 +9,19 @@ export async function getNoteListItems({ userId }: { userId: string }) {
   return data;
 }
 
+export async function deleteNote({ id, userId }) {
+  const { error } = await supabase
+    .from("notes")
+    .delete({ returning: "minimal" })
+    .match({ id, profile_id: userId });
+
+  if (!error) {
+    return {};
+  }
+
+  return null;
+}
+
 export async function getNote({ id, userId }) {
   const { data, error } = await supabase
     .from("notes")

--- a/app/routes/notes/$noteId.tsx
+++ b/app/routes/notes/$noteId.tsx
@@ -1,5 +1,5 @@
-import { Form, json, useLoaderData } from "remix";
-import { getNote } from "~/models/note.server";
+import { Form, json, redirect, useLoaderData } from "remix";
+import { deleteNote, getNote } from "~/models/note.server";
 import { requireUserId } from "~/session.server";
 
 export const loader: LoaderFunction = async ({ request, params }) => {
@@ -11,6 +11,14 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   }
 
   return json({ note });
+};
+
+export const action: ActionFunction = async ({ request, params }) => {
+  const userId = await requireUserId(request);
+
+  await deleteNote({ userId, id: params.noteId });
+
+  return redirect("/notes");
 };
 
 export default function NoteDetailsPage() {


### PR DESCRIPTION
## Summary

With the work of #14 on `pw/14/notes`. We can now extend the behavior so a user can be able to view or delete a given note! This is currently able to be merged onto `pw/14/notes` but it might be better to wait for #29 to be merged in so we have concise commits across each little feature.

![Showing off an individual note with the contents of "This is a test" as the title and "This is a test" as the body](https://user-images.githubusercontent.com/8431042/159269216-bac91935-32e3-474b-9848-bd4f01ffae89.png)


### Technical Detail

For the most part viewing a note requires two things: `profile_id` and `id` of the note. When we go to Supabase we find our particular note that match on those two conditions. **Important**: Supabase by default of `.select()` will return an array of items. To avoid this, we can use `.single` and it will return back the first object from the array. Given the constraints of our request and our database, we can guarantee there will only ever be 1 record that matches to the query.

Deleting a record requires the same information, where we just need to find our record with the correct `profile_id` and `id`. However, for security reasons (e.g. not having extra data coming through), I decided to make sure that no data is sent back to us upon deletion unless it is an error. This is due to the `.delete({ returning: 'minimal' })`.

### Manual Testing

- Log in as a user `prince@code.com` and `prince`
- Click any of the available notes on the left hand bar
- The detail view should appear on the right with a delete button
- Click the delete button and verify the list on the left updates eliminating the note that was deleted.

### Relevant Documentation and Issues

- Closes #15 
- Closes #24 
- [Supabase docs - Delete data](https://supabase.com/docs/reference/javascript/delete)
- [Supabase docs - Filtering `.match()`](https://supabase.com/docs/reference/javascript/match)