### PR TITLE
chore (#42): removes msw and vitest icons

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -86,16 +86,6 @@ export default function Index() {
                 href: "https://www.cypress.io",
               },
               {
-                src: "https://user-images.githubusercontent.com/1500684/157772386-75444196-0604-4340-af28-53b236faa182.svg",
-                alt: "MSW",
-                href: "https://mswjs.io",
-              },
-              {
-                src: "https://user-images.githubusercontent.com/1500684/157772447-00fccdce-9d12-46a3-8bb4-fac612cdc949.svg",
-                alt: "Vitest",
-                href: "https://vitest.dev",
-              },
-              {
                 src: "https://user-images.githubusercontent.com/1500684/157772662-92b0dd3a-453f-4d18-b8be-9fa6efde52cf.png",
                 alt: "Testing Library",
                 href: "https://testing-library.com",


### PR DESCRIPTION
closes #42 

removes icons for tools we didn't use: msw & vitest

before: 
<img width="955" alt="Screen Shot 2022-04-05 at 10 37 50 PM" src="https://user-images.githubusercontent.com/3611928/161885048-55895d22-3131-4844-8cb8-958ed4fd3543.png">


after
<img width="951" alt="Screen Shot 2022-04-05 at 10 37 38 PM" src="https://user-images.githubusercontent.com/3611928/161885031-c99747b5-58ac-4aea-adc9-cc70c94a0b7c.png">
: