### PR TITLE
chore: Add in the Remix instructions to setup Supabase

### DIFF
--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -71,7 +71,9 @@ async function main({ rootDirectory }) {
 
   console.log(
     `
-Setup is almost complete. Follow these steps to finish initialization:
+Setup is almost complete! Follow these steps to finish initialization:
+- Create a new Supabase project and perform the SQL queries described in the README.
+- Add your Supabase credentials (SUPABASE_URL and SUPABASE_ANON_KEY) in your .env file.
 - Run the first build (this generates the server you will run):
   npm run build
 - You're now ready to rock and roll 🤘


### PR DESCRIPTION
## Summary

To make sure it is clear for a user installing this that they need to read the README for the database instructions. We just modify the init script a bit and point folks the right places!

## Manual Testing

In order to make sure this all works, you'll want to:
- Clone this branch down
- Change out of the project directory
- Use the `npx create-remix@latest --template ./kpop-stack` to install the stack
- Ensure that the message matches the changes (e.g. includes supabase details)

Closes #44