### PR TITLE
chore: improve DX for k-pop template

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,30 @@ This starts your app in development mode, rebuilding assets on file changes.
 
 ### Running Locally
 
-Running `npm run dev` will also trigger the Netlify local development environment which will pull in all the [environment variables](https://docs.netlify.com/configure-builds/environment-variables/#declare-variables) of your Netlify project. You can learn more about this project's Supabase environment variables in [the Database section below](#database). With Netlify dev you can also:
+The Remix dev server starts your app in development mode, rebuilding assets on file changes. To start the Remix dev server:
+
+```sh
+npm run dev
+```
+
+The Netlify CLI builds a production version of your Remix App Server and splits it into Netlify Functions that run locally. This includes any custom Netlify functions you've developed. The Netlify CLI runs all of this in its development mode.
+
+It will pull in all the [environment variables](https://docs.netlify.com/configure-builds/environment-variables/#declare-variables) of your Netlify project. You can learn more about this project's Supabase environment variables in [the Database section below](#database).
+
+To start the Netlify development environment:
+
+```sh
+netlify dev
+```
+
+With Netlify dev you can also:
 
 - test functions
 - test redirects
 - share a live session via url with `netlify dev --live`
 - [and more](https://cli.netlify.com/netlify-dev/) :)
+
+Note: When running the Netlify CLI, file changes will rebuild assets, but you will not see the changes to the page you are on unless you do a browser refresh of the page. Due to how the Netlify CLI builds the Remix App Server, it does not support hot module reloading.
 
 ### Relevant code:
 
@@ -99,8 +117,8 @@ You will need these 2 environment variables to connect to your Supabase instance
 
   Found in Settings/API/Project API keys
   <details><summary> See screenshot</summary>
-    
-    ![supabase anon key location](https://res.cloudinary.com/dzkoxrsdj/image/upload/v1649193447/Screen_Shot_2022-04-05_at_5.15.45_PM_ipdgcc.jpg)
+
+  ![supabase anon key location](https://res.cloudinary.com/dzkoxrsdj/image/upload/v1649193447/Screen_Shot_2022-04-05_at_5.15.45_PM_ipdgcc.jpg)
 
   </details>
 
@@ -108,8 +126,8 @@ You will need these 2 environment variables to connect to your Supabase instance
 
   Found in Settings/API/Configuration/URL
   <details><summary> See screenshot</summary>
-    
-    ![supabase url location](https://res.cloudinary.com/dzkoxrsdj/image/upload/v1649193610/Screen_Shot_2022-04-05_at_5.18.12_PM_sj7mj8.jpg)
+
+  ![supabase url location](https://res.cloudinary.com/dzkoxrsdj/image/upload/v1649193610/Screen_Shot_2022-04-05_at_5.18.12_PM_sj7mj8.jpg)
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To start the Netlify development environment:
 netlify dev
 ```
 
-With Netlify dev you can also:
+With Netlify Dev you can also:
 
 - test functions
 - test redirects

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@remix-run/dev": "^1.4.3",
         "@remix-run/eslint-config": "^1.4.3",
+        "@remix-run/serve": "^1.4.3",
         "@testing-library/cypress": "^8.0.2",
         "@types/bcryptjs": "^2.4.2",
         "@types/eslint": "^8.4.1",
@@ -2453,6 +2454,63 @@
         }
       }
     },
+    "node_modules/@remix-run/express": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.6.5.tgz",
+      "integrity": "sha512-oakTyUF9ycowIaAoNet7z4vqL8mzuImH5fmAcD62ueP7lBS/vp9twJl3vjcvbsRBTquwVy+tNncBZhHor1t8lg==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/node": "1.6.5"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "express": "^4.17.1"
+      }
+    },
+    "node_modules/@remix-run/express/node_modules/@remix-run/node": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.6.5.tgz",
+      "integrity": "sha512-UMy775OV7LTzGCEpP9g7LUDYY/Rc5JUT5jgjK4vP4P+GHCTpnHjWdvloda379oN5JiRuMDD3IXwg2wnMNzrWPQ==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/server-runtime": "1.6.5",
+        "@remix-run/web-fetch": "^4.1.3",
+        "@remix-run/web-file": "^3.0.2",
+        "@remix-run/web-stream": "^1.0.3",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/express/node_modules/@remix-run/server-runtime": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.6.5.tgz",
+      "integrity": "sha512-4QJeIWFWcXZbSPaXUR3V0XzsF0TALuuoQJGEPhtaRP/oX/relE8T36hCmsBDwe0gQM6nyanU2q8vG8BoOQqulQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookie": "^0.4.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.4.1",
+        "jsesc": "3.0.2",
+        "react-router-dom": "^6.2.2",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@remix-run/netlify": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@remix-run/netlify/-/netlify-1.4.3.tgz",
@@ -2495,6 +2553,24 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@remix-run/serve": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-1.6.5.tgz",
+      "integrity": "sha512-xkGnjG4QypMrAvP6py724FZDIQG/3r9FmkjjxielE691h/ZCtJOCDSkifrKqCKf4MK60cDagI8zZ/NELcWLPjA==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/express": "1.6.5",
+        "compression": "^1.7.4",
+        "express": "^4.17.1",
+        "morgan": "^1.10.0"
+      },
+      "bin": {
+        "remix-serve": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@remix-run/server-runtime": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.4.3.tgz",
@@ -2510,6 +2586,60 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@remix-run/web-blob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.0.4.tgz",
+      "integrity": "sha512-AfegzZvSSDc+LwnXV+SwROTrDtoLiPxeFW+jxgvtDAnkuCX1rrzmVJ6CzqZ1Ai0bVfmJadkG5GxtAfYclpPmgw==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/web-stream": "^1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/@remix-run/web-fetch": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.1.3.tgz",
+      "integrity": "sha512-D3KXAEkzhR248mu7wCHReQrMrIo3Y9pDDa7TrlISnsOEvqkfWkJJF+PQWmOIKpOSHAhDg7TCb2tzvW8lc/MfHw==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/web-blob": "^3.0.4",
+        "@remix-run/web-form-data": "^3.0.2",
+        "@remix-run/web-stream": "^1.0.3",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
+      },
+      "engines": {
+        "node": "^10.17 || >=12.3"
+      }
+    },
+    "node_modules/@remix-run/web-file": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.0.2.tgz",
+      "integrity": "sha512-eFC93Onh/rZ5kUNpCQersmBtxedGpaXK2/gsUl49BYSGK/DvuPu3l06vmquEDdcPaEuXcsdGP0L7zrmUqrqo4A==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/web-blob": "^3.0.3"
+      }
+    },
+    "node_modules/@remix-run/web-form-data": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.0.2.tgz",
+      "integrity": "sha512-F8tm3iB1sPxMpysK6Js7lV3gvLfTNKGmIW38t/e6dtPEB5L1WdbRG1cmLyhsonFc7rT1x1JKdz+2jCtoSdnIUw==",
+      "dev": true,
+      "dependencies": {
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/@remix-run/web-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.0.3.tgz",
+      "integrity": "sha512-wlezlJaA5NF6SsNMiwQnnAW6tnPzQ5I8qk0Y0pSohm0eHKa2FQ1QhEKLVVcDDu02TmkfHgnux0igNfeYhDOXiA==",
+      "dev": true,
+      "dependencies": {
+        "web-streams-polyfill": "^3.1.1"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -3204,6 +3334,12 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
+    "node_modules/@web3-storage/multipart-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
+      "dev": true
+    },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
@@ -3851,6 +3987,24 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -4695,6 +4849,66 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/compression/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5066,6 +5280,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/dayjs": {
@@ -10866,6 +11089,46 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -10873,6 +11136,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -11423,6 +11695,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -13674,6 +13955,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
+    "node_modules/stream-slice": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
+      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==",
       "dev": true
     },
     "node_modules/streamsearch": {
@@ -16952,6 +17239,49 @@
         "eslint-plugin-testing-library": "^5.0.5"
       }
     },
+    "@remix-run/express": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.6.5.tgz",
+      "integrity": "sha512-oakTyUF9ycowIaAoNet7z4vqL8mzuImH5fmAcD62ueP7lBS/vp9twJl3vjcvbsRBTquwVy+tNncBZhHor1t8lg==",
+      "dev": true,
+      "requires": {
+        "@remix-run/node": "1.6.5"
+      },
+      "dependencies": {
+        "@remix-run/node": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.6.5.tgz",
+          "integrity": "sha512-UMy775OV7LTzGCEpP9g7LUDYY/Rc5JUT5jgjK4vP4P+GHCTpnHjWdvloda379oN5JiRuMDD3IXwg2wnMNzrWPQ==",
+          "dev": true,
+          "requires": {
+            "@remix-run/server-runtime": "1.6.5",
+            "@remix-run/web-fetch": "^4.1.3",
+            "@remix-run/web-file": "^3.0.2",
+            "@remix-run/web-stream": "^1.0.3",
+            "@web3-storage/multipart-parser": "^1.0.0",
+            "abort-controller": "^3.0.0",
+            "cookie-signature": "^1.1.0",
+            "source-map-support": "^0.5.21",
+            "stream-slice": "^0.1.2"
+          }
+        },
+        "@remix-run/server-runtime": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.6.5.tgz",
+          "integrity": "sha512-4QJeIWFWcXZbSPaXUR3V0XzsF0TALuuoQJGEPhtaRP/oX/relE8T36hCmsBDwe0gQM6nyanU2q8vG8BoOQqulQ==",
+          "dev": true,
+          "requires": {
+            "@types/cookie": "^0.4.0",
+            "@web3-storage/multipart-parser": "^1.0.0",
+            "cookie": "^0.4.1",
+            "jsesc": "3.0.2",
+            "react-router-dom": "^6.2.2",
+            "set-cookie-parser": "^2.4.8",
+            "source-map": "^0.7.3"
+          }
+        }
+      }
+    },
     "@remix-run/netlify": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@remix-run/netlify/-/netlify-1.4.3.tgz",
@@ -16987,6 +17317,18 @@
         "react-router-dom": "^6.2.2"
       }
     },
+    "@remix-run/serve": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-1.6.5.tgz",
+      "integrity": "sha512-xkGnjG4QypMrAvP6py724FZDIQG/3r9FmkjjxielE691h/ZCtJOCDSkifrKqCKf4MK60cDagI8zZ/NELcWLPjA==",
+      "dev": true,
+      "requires": {
+        "@remix-run/express": "1.6.5",
+        "compression": "^1.7.4",
+        "express": "^4.17.1",
+        "morgan": "^1.10.0"
+      }
+    },
     "@remix-run/server-runtime": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.4.3.tgz",
@@ -16998,6 +17340,57 @@
         "react-router-dom": "^6.2.2",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
+      }
+    },
+    "@remix-run/web-blob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.0.4.tgz",
+      "integrity": "sha512-AfegzZvSSDc+LwnXV+SwROTrDtoLiPxeFW+jxgvtDAnkuCX1rrzmVJ6CzqZ1Ai0bVfmJadkG5GxtAfYclpPmgw==",
+      "dev": true,
+      "requires": {
+        "@remix-run/web-stream": "^1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "@remix-run/web-fetch": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.1.3.tgz",
+      "integrity": "sha512-D3KXAEkzhR248mu7wCHReQrMrIo3Y9pDDa7TrlISnsOEvqkfWkJJF+PQWmOIKpOSHAhDg7TCb2tzvW8lc/MfHw==",
+      "dev": true,
+      "requires": {
+        "@remix-run/web-blob": "^3.0.4",
+        "@remix-run/web-form-data": "^3.0.2",
+        "@remix-run/web-stream": "^1.0.3",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
+      }
+    },
+    "@remix-run/web-file": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.0.2.tgz",
+      "integrity": "sha512-eFC93Onh/rZ5kUNpCQersmBtxedGpaXK2/gsUl49BYSGK/DvuPu3l06vmquEDdcPaEuXcsdGP0L7zrmUqrqo4A==",
+      "dev": true,
+      "requires": {
+        "@remix-run/web-blob": "^3.0.3"
+      }
+    },
+    "@remix-run/web-form-data": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.0.2.tgz",
+      "integrity": "sha512-F8tm3iB1sPxMpysK6Js7lV3gvLfTNKGmIW38t/e6dtPEB5L1WdbRG1cmLyhsonFc7rT1x1JKdz+2jCtoSdnIUw==",
+      "dev": true,
+      "requires": {
+        "web-encoding": "1.1.5"
+      }
+    },
+    "@remix-run/web-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.0.3.tgz",
+      "integrity": "sha512-wlezlJaA5NF6SsNMiwQnnAW6tnPzQ5I8qk0Y0pSohm0eHKa2FQ1QhEKLVVcDDu02TmkfHgnux0igNfeYhDOXiA==",
+      "dev": true,
+      "requires": {
+        "web-streams-polyfill": "^3.1.1"
       }
     },
     "@rollup/pluginutils": {
@@ -17562,6 +17955,12 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
+    "@web3-storage/multipart-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
+      "dev": true
+    },
     "@zxing/text-encoding": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
@@ -18019,6 +18418,23 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -18655,6 +19071,59 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -18947,6 +19416,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "dev": true
     },
     "dayjs": {
       "version": "1.11.0",
@@ -23133,10 +23608,52 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        }
+      }
+    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
+    },
+    "mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
       "dev": true
     },
     "ms": {
@@ -23551,6 +24068,12 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -25281,6 +25804,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
+    "stream-slice": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
+      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==",
       "dev": true
     },
     "streamsearch": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:remix": "cross-env NODE_ENV=production remix build",
     "dev": "run-p dev:*",
     "dev:css": "npm run generate:css -- --watch",
-    "dev:remix": "cross-env NODE_ENV=development netlify dev",
+    "dev:remix": "remix dev",
     "e2e-test": "cypress run",
     "format": "prettier --write .",
     "generate:css": "npx tailwindcss -o ./app/styles/tailwind.css",
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@remix-run/dev": "^1.4.3",
     "@remix-run/eslint-config": "^1.4.3",
+    "@remix-run/serve": "^1.4.3",
     "@testing-library/cypress": "^8.0.2",
     "@types/bcryptjs": "^2.4.2",
     "@types/eslint": "^8.4.1",

--- a/remix.config.js
+++ b/remix.config.js
@@ -1,13 +1,13 @@
-/**
- * @type {import('@remix-run/dev').AppConfig}
- */
+/** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   serverBuildTarget: "netlify",
-  server: "./server.js",
-  ignoredRouteFiles: [".*"],
+  server:
+    process.env.NETLIFY || process.env.NETLIFY_LOCAL
+      ? "./server.js"
+      : undefined,
+  ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
-  // serverBuildPath: "netlify/functions/server/index.js",
+  // serverBuildPath: ".netlify/functions-internal/server.js",
   // publicPath: "/build/",
-  // devServerPort: 8002
 };


### PR DESCRIPTION
## Description

This changes the npm `dev` script to run `remix dev` so that a developer can build their app and get all the hot reloading goodness that the Remix dev server provides.

When they want to test the serverless version, they can run `netlify dev`. The main difference is when running `ntl dev`, they are required to do a browser refresh of the page to see the changes they made.

For more context, see https://github.com/remix-run/remix/discussions/3753.

Closes #57

## Test Steps

1. Pull this PR locally, `gh co 56`
2. Install the dependencies via `npm install`
3. Configure the environment variables and database as specified in the README.

## Test the Remix dev server

1. Run `npm run dev`
2. The Remix dev server starts and renders the main page when navigating to http://localhost:3000
3. Stop the Remix dev server.

## Test the Remix app server running in Netlify functions locally

1. Run `netlify dev`.  
2. The server running on Netlify functions locally starts and renders the main page when navigating to http://localhost:3000.

## Test a deploy via the CLI

1. Run `netlify deploy --build`. If your application isn't configured to deploy yet, ensure you've followed the steps in the README first to get your app configured to deploy to Netlify.
2. The application builds and deploys.
3. Navigate to the deploy preview.
4. The site loads.

## Test a deploy via git push or retrigger a deploy from the Netlify UI

1. Trigger a deploy from the Netlify UI, and ensure the site builds and uploads the Netlify functions.
2. Navigate back to the URL associated with the triggered deploy.
3. The site loads

![A Quokka happy to be eating](https://media.giphy.com/media/yxVRICzg06MyG73Kb6/giphy.gif)