### PR TITLE
bump: @supabase/supabase-js to 2.1.1

### DIFF
--- a/app/models/note.server.ts
+++ b/app/models/note.server.ts
@@ -25,6 +25,7 @@ export async function createNote({
   const { data, error } = await supabase
     .from("notes")
     .insert([{ title, body, profile_id: userId }])
+    .select()
     .single();
 
   if (!error) {
@@ -40,7 +41,7 @@ export async function deleteNote({
 }: Pick<Note, "id"> & { userId: User["id"] }) {
   const { error } = await supabase
     .from("notes")
-    .delete({ returning: "minimal" })
+    .delete()
     .match({ id, profile_id: userId });
 
   if (!error) {

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -1,4 +1,3 @@
-import bcrypt from "bcryptjs";
 import { createClient } from "@supabase/supabase-js";
 import invariant from "tiny-invariant";
 
@@ -20,13 +19,13 @@ invariant(
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export async function createUser(email: string, password: string) {
-  const { user } = await supabase.auth.signUp({
+  const { data } = await supabase.auth.signUp({
     email,
     password,
   });
 
   // get the user profile after created
-  const profile = await getProfileByEmail(user?.email);
+  const profile = await getProfileByEmail(data.user?.email);
 
   return profile;
 }
@@ -54,13 +53,13 @@ export async function getProfileByEmail(email?: string) {
 }
 
 export async function verifyLogin(email: string, password: string) {
-  const { user, error } = await supabase.auth.signIn({
+  const { data, error } = await supabase.auth.signInWithPassword({
     email,
     password,
   });
 
   if (error) return undefined;
-  const profile = await getProfileByEmail(user?.email);
+  const profile = await getProfileByEmail(data.user?.email);
 
   return profile;
 }

--- a/app/routes/join.tsx
+++ b/app/routes/join.tsx
@@ -71,6 +71,13 @@ export const action: ActionFunction = async ({ request }) => {
 
   const user = await createUser(email, password);
 
+  if (!user) {
+    return json<ActionData>(
+      { errors: { email: "Failed to create user." } },
+      { status: 500 }
+    );
+  }
+
   return createUserSession({
     request,
     userId: user.id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@remix-run/netlify": "^1.6.8",
         "@remix-run/node": "^1.6.8",
         "@remix-run/react": "^1.6.8",
-        "@supabase/supabase-js": "^1.31.1",
+        "@supabase/supabase-js": "^2.1.1",
         "@testing-library/cypress": "^8.0.3",
         "bcryptjs": "^2.4.3",
         "cypress": "^10.4.0",
@@ -2642,56 +2642,57 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-1.3.4.tgz",
-      "integrity": "sha512-yYVgkECjv7IZEBKBI3EB5Q7R1p0FJ10g8Q9N7SWKIHUU6i6DnbEGHIMFLyQRm1hmiNWD8fL7bRVEYacmTRJhHw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.0.0.tgz",
+      "integrity": "sha512-ozb7bds2yvf5k7NM2ZzUkxvsx4S4i2eRKFSJetdTADV91T65g4gCzEs9L3LUXSrghcGIkUaon03VPzOrFredqg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "1.22.22",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.22.tgz",
-      "integrity": "sha512-exbCopLo4tLawKZR25wEdipm+IRVujuqFRR4h2wiXd11YA+N8rfgg/4S4L6BTFHmzV+KMjy0kDF3yMbsjIR/xA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.4.2.tgz",
+      "integrity": "sha512-OjonGyH0DvFcLAM9QrX73hSM6qXBAvgnISyOvjidUUIh9GgcYAJRWWysjN7Rn3QVpKNGQ65JE6gkuXBIGz1gcg==",
       "dependencies": {
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "0.37.4",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-0.37.4.tgz",
-      "integrity": "sha512-x+c2rk1fz9s6f1PrGxCJ0QTUgXPDI0G3ngIqD5sSiXhhCyfl8Q5V92mXl2EYtlDhkiUkjFNrOZFhXVbXOHgvDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.1.0.tgz",
+      "integrity": "sha512-qkY8TqIu5sJuae8gjeDPjEqPrefzcTraW9PNSVJQHq4TEv98ZmwaXGwBGz0bVL63bqrGA5hqREbQHkANUTXrvA==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-1.7.5.tgz",
-      "integrity": "sha512-nXuoxt7NE1NTI+G8WBim1K2gkUC8YE3e9evBUG+t6xwd9Sq+sSOrjcE0qJ8/Y631BCnLzlhX6yhFYQFh1oQDOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.1.0.tgz",
+      "integrity": "sha512-iplLCofTeYjnx9FIOsIwHLhMp0+7UVyiA4/sCeq40VdOgN9eTIhjEno9Tgh4dJARi4aaXoKfRX1DTxgZaOpPAw==",
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "websocket": "^1.0.34"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.7.3.tgz",
-      "integrity": "sha512-jnIZWqOc9TGclOozgX9v/RWGFCgJAyW/yvmauexgRZhWknUXoA4b2i8tj7vfwE0WTvNRuA5JpXID98rfJeSG7Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.0.0.tgz",
+      "integrity": "sha512-7kXThdRt/xqnOOvZZxBqNkeX1CFNUWc0hYBJtNN/Uvt8ok9hD14foYmroWrHn046wEYFqUrB9U35JYsfTrvltA==",
       "dependencies": {
-        "cross-fetch": "^3.1.0"
+        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "1.35.7",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-1.35.7.tgz",
-      "integrity": "sha512-X+qCzmj5sH0dozagbLoK7LzysBaWoivO0gsAUAPPBQkQupQWuBfaOqG18gKhlfL0wp2PL888QzhQNScp/IwUfA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.1.1.tgz",
+      "integrity": "sha512-6uBz31zrYfXkb5f2lzSHtncLWDQG5LvuH/OrmIAJqnjvliyd1pXMCGn/03xTfnflbjMolbOva+XMrydkyIMDfQ==",
       "dependencies": {
-        "@supabase/functions-js": "^1.3.4",
-        "@supabase/gotrue-js": "^1.22.21",
-        "@supabase/postgrest-js": "^0.37.4",
-        "@supabase/realtime-js": "^1.7.5",
-        "@supabase/storage-js": "^1.7.2"
+        "@supabase/functions-js": "^2.0.0",
+        "@supabase/gotrue-js": "^2.3.1",
+        "@supabase/postgrest-js": "^1.1.0",
+        "@supabase/realtime-js": "^2.1.0",
+        "@supabase/storage-js": "^2.0.0",
+        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -7340,11 +7341,11 @@
       ]
     },
     "node_modules/ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "dependencies": {
-        "type": "^2.5.0"
+        "type": "^2.7.2"
       }
     },
     "node_modules/ext/node_modules/type": {
@@ -18469,56 +18470,57 @@
       "dev": true
     },
     "@supabase/functions-js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-1.3.4.tgz",
-      "integrity": "sha512-yYVgkECjv7IZEBKBI3EB5Q7R1p0FJ10g8Q9N7SWKIHUU6i6DnbEGHIMFLyQRm1hmiNWD8fL7bRVEYacmTRJhHw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.0.0.tgz",
+      "integrity": "sha512-ozb7bds2yvf5k7NM2ZzUkxvsx4S4i2eRKFSJetdTADV91T65g4gCzEs9L3LUXSrghcGIkUaon03VPzOrFredqg==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/gotrue-js": {
-      "version": "1.22.22",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-1.22.22.tgz",
-      "integrity": "sha512-exbCopLo4tLawKZR25wEdipm+IRVujuqFRR4h2wiXd11YA+N8rfgg/4S4L6BTFHmzV+KMjy0kDF3yMbsjIR/xA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.4.2.tgz",
+      "integrity": "sha512-OjonGyH0DvFcLAM9QrX73hSM6qXBAvgnISyOvjidUUIh9GgcYAJRWWysjN7Rn3QVpKNGQ65JE6gkuXBIGz1gcg==",
       "requires": {
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/postgrest-js": {
-      "version": "0.37.4",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-0.37.4.tgz",
-      "integrity": "sha512-x+c2rk1fz9s6f1PrGxCJ0QTUgXPDI0G3ngIqD5sSiXhhCyfl8Q5V92mXl2EYtlDhkiUkjFNrOZFhXVbXOHgvDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.1.0.tgz",
+      "integrity": "sha512-qkY8TqIu5sJuae8gjeDPjEqPrefzcTraW9PNSVJQHq4TEv98ZmwaXGwBGz0bVL63bqrGA5hqREbQHkANUTXrvA==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/realtime-js": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-1.7.5.tgz",
-      "integrity": "sha512-nXuoxt7NE1NTI+G8WBim1K2gkUC8YE3e9evBUG+t6xwd9Sq+sSOrjcE0qJ8/Y631BCnLzlhX6yhFYQFh1oQDOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.1.0.tgz",
+      "integrity": "sha512-iplLCofTeYjnx9FIOsIwHLhMp0+7UVyiA4/sCeq40VdOgN9eTIhjEno9Tgh4dJARi4aaXoKfRX1DTxgZaOpPAw==",
       "requires": {
         "@types/phoenix": "^1.5.4",
         "websocket": "^1.0.34"
       }
     },
     "@supabase/storage-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.7.3.tgz",
-      "integrity": "sha512-jnIZWqOc9TGclOozgX9v/RWGFCgJAyW/yvmauexgRZhWknUXoA4b2i8tj7vfwE0WTvNRuA5JpXID98rfJeSG7Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.0.0.tgz",
+      "integrity": "sha512-7kXThdRt/xqnOOvZZxBqNkeX1CFNUWc0hYBJtNN/Uvt8ok9hD14foYmroWrHn046wEYFqUrB9U35JYsfTrvltA==",
       "requires": {
-        "cross-fetch": "^3.1.0"
+        "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/supabase-js": {
-      "version": "1.35.7",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-1.35.7.tgz",
-      "integrity": "sha512-X+qCzmj5sH0dozagbLoK7LzysBaWoivO0gsAUAPPBQkQupQWuBfaOqG18gKhlfL0wp2PL888QzhQNScp/IwUfA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.1.1.tgz",
+      "integrity": "sha512-6uBz31zrYfXkb5f2lzSHtncLWDQG5LvuH/OrmIAJqnjvliyd1pXMCGn/03xTfnflbjMolbOva+XMrydkyIMDfQ==",
       "requires": {
-        "@supabase/functions-js": "^1.3.4",
-        "@supabase/gotrue-js": "^1.22.21",
-        "@supabase/postgrest-js": "^0.37.4",
-        "@supabase/realtime-js": "^1.7.5",
-        "@supabase/storage-js": "^1.7.2"
+        "@supabase/functions-js": "^2.0.0",
+        "@supabase/gotrue-js": "^2.3.1",
+        "@supabase/postgrest-js": "^1.1.0",
+        "@supabase/realtime-js": "^2.1.0",
+        "@supabase/storage-js": "^2.0.0",
+        "cross-fetch": "^3.1.5"
       }
     },
     "@szmarczak/http-timer": {
@@ -21924,11 +21926,11 @@
       }
     },
     "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "requires": {
-        "type": "^2.5.0"
+        "type": "^2.7.2"
       },
       "dependencies": {
         "type": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@remix-run/netlify": "^1.6.8",
     "@remix-run/node": "^1.6.8",
     "@remix-run/react": "^1.6.8",
-    "@supabase/supabase-js": "^1.31.1",
+    "@supabase/supabase-js": "^2.1.1",
     "@testing-library/cypress": "^8.0.3",
     "bcryptjs": "^2.4.3",
     "cypress": "^10.4.0",


### PR DESCRIPTION
## Summary

This PR bumps the version of `@supabase/supabase-js` to v2.1.1. As there were breaking changes in version 2, this PR also updates the relevant areas of the codebase so that it conforms to the new apis & types.

This is my first time contributing - if there's anything I should be doing please let me know :)